### PR TITLE
str(RESOURCE_PATH)

### DIFF
--- a/japanize_kivy/japanizer.py
+++ b/japanize_kivy/japanizer.py
@@ -10,7 +10,7 @@ from kivy.core.text import LabelBase
 from kivy.core.text import DEFAULT_FONT
 
 
-RESOURCE_PATH = pathlib.Path(__file__).parent / 'resources/ipaexg00401'
+RESOURCE_PATH = str(pathlib.Path(__file__).parent / 'resources/ipaexg00401')
 
 
 def japanize():


### PR DESCRIPTION
to avoid errors on Linux:

 Traceback (most recent call last):
   File "main.py", line 1, in <module>
     import japanize_kivy
   File "/home/tamo/japanize-kivy/japanize_kivy/__init__.py", line 14, in <module>
     japanize()
   File "/home/tamo/japanize-kivy/japanize_kivy/japanizer.py", line 18, in japanize
     LabelBase.register(DEFAULT_FONT, 'ipaexg.ttf')
   File "/home/tamo/.local/lib/python3.5/site-packages/kivy/core/text/__init__.py", line 312, in register
     font = resource_find(font_type)
   File "/home/tamo/.local/lib/python3.5/site-packages/kivy/resources.py", line 57, in resource_find
     output = abspath(join(path, filename))
   File "/usr/lib/python3.5/posixpath.py", line 89, in join
     genericpath._check_arg_types('join', a, *p)
   File "/usr/lib/python3.5/genericpath.py", line 143, in _check_arg_types
     (funcname, s.__class__.__name__)) from None
 TypeError: join() argument must be str or bytes, not 'PosixPath'