### PR TITLE
setuptools-scm でバージョンを一元管理する

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm がタグからバージョンを取得するため、すべて取得する
+          fetch-depth: 0
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -41,6 +44,9 @@ jobs:
           - "3.13"
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm がタグからバージョンを取得するため、すべて取得する
+          fetch-depth: 0
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:
@@ -60,6 +66,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          # setuptools-scm がタグからバージョンを取得するため、すべて取得する
+          fetch-depth: 0
       - name: Set up uv
         uses: astral-sh/setup-uv@v6
         with:

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,1 +1,0 @@
-include japanize_kivy/resources/**/*

--- a/japanize_kivy/__init__.py
+++ b/japanize_kivy/__init__.py
@@ -1,7 +1,9 @@
+from importlib.metadata import version
+
 from japanize_kivy.japanizer import japanize
 from japanize_kivy.japanizer import show_license
 
-__version__ = "0.1.1"
+__version__ = version("japanize-kivy")
 
 __all__ = ["japanize", "show_license"]
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["setuptools>=77"]
+requires = ["setuptools>=77", "setuptools-scm>=8"]
 build-backend = "setuptools.build_meta"
 
 [project]
@@ -40,14 +40,14 @@ dev = [
 [tool.setuptools]
 zip-safe = false
 
-[tool.setuptools.dynamic]
-version = { attr = "japanize_kivy.__version__" }
-
 [tool.setuptools.packages.find]
 include = ["japanize_kivy*"]
 
 [tool.setuptools.package-data]
 japanize_kivy = ["resources/**/*"]
+
+# バージョンは Git のタグから取得する
+[tool.setuptools_scm]
 
 [tool.pytest.ini_options]
 addopts = "-v"


### PR DESCRIPTION
バージョンの管理を Git のタグに一本化する。

これまでは `japanize_kivy/__init__.py` の `__version__` リテラルが情報源で、リリースのたびに手で書き換えて、別途タグを打つ必要があった。タグと実際のバージョンがずれる余地があるので、shirokumas と同じく setuptools-scm を使ってタグを単一の情報源にする。

## 変更内容

- ビルド時に setuptools-scm が Git のタグからバージョンを決定するようにする
- 実行時の `__version__` は `importlib.metadata.version()` でパッケージのメタデータから取得する
  - ビルド時とインストール後で同じ値になる
- CI の checkout で `fetch-depth: 0` を指定する
  - 既定の浅いクローンだとタグが取得できず、バージョンを決定できない
- `MANIFEST.in` を削除する
  - setuptools-scm が Git の管理下にあるファイルを sdist に含めるため、役割が重複する

## リリース手順への影響

`__version__` の書き換えは不要になり、タグを打つだけでよくなる。

```sh
$ git tag 0.2.0
$ git push origin 0.2.0
$ uv build
```

## 動作確認

- クローンしたリポジトリに `0.2.0` タグを打って `uv build` すると、`japanize_kivy-0.2.0` が生成されることを確認した
  - タグのない状態では `0.1.2.dev3+g3c2d61a4e` のような開発版になる
- ビルドした wheel を導入すると、`japanize_kivy.__version__` とパッケージのメタデータのバージョンが一致することを確認した
- `twine check` が sdist / wheel の両方で PASSED になる
- `tox` (lint + py310 - py313) がすべて成功する
- 日本語が IPAex ゴシックで表示されることを確認済み