### PR TITLE
Dependabot で Action のバージョンを更新する

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,9 @@
+version: 2
+
+updates:
+
+  # ワークフローが参照している Action のバージョンを更新する
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"


### PR DESCRIPTION
GitHub Actions のバージョン更新を Dependabot に任せる。

設定は shirokumas を踏襲して、`github-actions` を weekly で更新する。

## Python の依存関係について

`pip` ecosystem は追加していない。このリポジトリの依存 (kivy, pytest, ruff) はバージョンを固定しておらず、ロックファイルもないため、Dependabot が更新できる対象がないため。

## マージ後に来る PR

現状のワークフローが参照している Action はいずれもメジャーバージョンが古いため、マージ後に Dependabot が更新の PR を出すはず。

| Action | 現在 | 最新 |
| --- | --- | --- |
| `actions/checkout` | v4 | v7.0.1 |
| `actions/upload-artifact` | v4 | v7.0.1 |
| `astral-sh/setup-uv` | v6 | v10.0.1 |

この PR でまとめて上げてしまうことも考えたが、#6 が同じワークフローファイルを触っているのでコンフリクトを避けた。Dependabot の PR ごとに CI で検証されるので、そちらで上げるほうが安全だと判断した。